### PR TITLE
fix #145 UI: canvas is too blurry

### DIFF
--- a/src/emulators-ui.css
+++ b/src/emulators-ui.css
@@ -12,7 +12,7 @@
 
 .emulator-canvas, .emulator-video {
     image-rendering: -moz-crisp-edges;
-    image-rendering: -webkit-crisp-edges;
+    image-rendering: crisp-edges;
     image-rendering: pixelated;
     -webkit-touch-callout: none;
     -webkit-user-select: none;

--- a/src/emulators-ui.css
+++ b/src/emulators-ui.css
@@ -11,7 +11,9 @@
 }
 
 .emulator-canvas, .emulator-video {
-    image-rendering: "crisp-edges";
+    image-rendering: -moz-crisp-edges;
+    image-rendering: -webkit-crisp-edges;
+    image-rendering: pixelated;
     -webkit-touch-callout: none;
     -webkit-user-select: none;
     -khtml-user-select: none;


### PR DESCRIPTION
https://github.com/caiiiycuk/js-dos/issues/145

Well, `pixelated` is simple `nearest-neighbor` and supported by all but Firefox.

https://caniuse.com/css-crisp-edges

Firefox supports only `crisp-edges`.
https://developer.mozilla.org/en-US/docs/Games/Techniques/Crisp_pixel_art_look

There is another way.
`ctx.imageSmoothingEnabled = false`, but this property is not supported by webgl context.
https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled