### PR TITLE
Use rgba() instead of space-separated rgb()

### DIFF
--- a/src/emulators-ui.css
+++ b/src/emulators-ui.css
@@ -155,7 +155,7 @@
     border-color: rgba(255, 255, 255, 0.5);
 
     border-style: solid;
-    box-shadow: 0 0 2px 2px rgb(255 255 255 / 50%), inset 0 0 2px 2px rgb(255 255 255 / 50%);
+    box-shadow: 0 0 2px 2px rgba(255, 255, 255, 0.5), inset 0 0 2px 2px rgba(255, 255, 255, 0.5);
 }
 
 .emulator-button {


### PR DESCRIPTION
Better compatibility and consistency with other rgba() function.
As [CSS Color Module Level 4](https://www.w3.org/TR/css-color-4/#funcdef-rgb) is still a working draft.