### PR TITLE
Use flex-end in justify-content instead of end

### DIFF
--- a/src/emulators-ui.css
+++ b/src/emulators-ui.css
@@ -209,7 +209,7 @@
 }
 
 .emulator-options {
-    justify-content: end;
+    justify-content: flex-end;
     flex-wrap: wrap-reverse;
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
This will cause a warning in PostCSS
`end value has mixed support, consider using flex-end instead`
See https://github.com/postcss/autoprefixer/blob/main/test/autoprefixer.test.ts#L818
See Also https://caniuse.com/mdn-css_properties_justify-content_flex_context_start_end